### PR TITLE
feat: Add max_tokens option to generate_content

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -412,6 +412,9 @@ components:
               - stream-end: Stream completion
 
               **Note:** Depending on the provider, some events may not be present.
+        max_tokens:
+          type: integer
+          description: Maximum number of tokens to generate
         tools:
           type: array
           items:


### PR DESCRIPTION
## Summary

This feature allow to limit the amount of generated tokens by the LLM request, making it more efficient for quick task that you just want the LLM to "think" less.