### PR TITLE
ci: restrict default workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: crates.io
 
+permissions:
+  contents: read
+
 jobs:
   github_release:
     name: GitHub Release


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` block to workflows that omitted one, so the default `GITHUB_TOKEN` carries only the scope the workflow needs. Jobs that declare their own `permissions:` block are unaffected (job-level blocks override the top-level one), and the org default token is already read-only, so this is behavior-preserving.

Refs inference-gateway/.github#96