### PR TITLE
ci: add deterministic schemas type sync

### DIFF
--- a/.github/workflows/schemas-sync.yml
+++ b/.github/workflows/schemas-sync.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ''
+      dry_run:
+        description: 'Preview the regeneration diff in the job summary without opening/updating a PR'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -24,4 +29,5 @@ jobs:
     with:
       language: rust
       ref: ${{ inputs.ref }}
+      dry_run: ${{ inputs.dry_run }}
     secrets: inherit

--- a/.github/workflows/schemas-sync.yml
+++ b/.github/workflows/schemas-sync.yml
@@ -1,0 +1,27 @@
+---
+name: Schemas Sync
+
+# Thin caller of the org reusable deterministic schemas->types sync. Runs
+# `task oas-sync SCHEMAS_REF=<ref>` and opens/updates an idempotent PR on the
+# fixed `schemas-sync` branch. Dispatched per repo, or fanned out from
+# inference-gateway/schemas' sync-downstream.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'schemas ref to sync (refs/tags/vX.Y.Z, refs/heads/main, or a SHA). Empty = latest schemas release.'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    uses: inference-gateway/.github/.github/workflows/schemas-sync.yml@main
+    with:
+      language: rust
+      ref: ${{ inputs.ref }}
+    secrets: inherit

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,9 +2,9 @@ version: "3"
 
 tasks:
   oas-download:
-    desc: Download OpenAPI specification
+    desc: Download OpenAPI specification (pin with SCHEMAS_REF=refs/tags/vX.Y.Z, a branch ref, or a SHA)
     cmds:
-      - curl -o openapi.yaml https://raw.githubusercontent.com/inference-gateway/schemas/refs/heads/main/openapi.yaml
+      - curl -fsSL -o openapi.yaml "https://raw.githubusercontent.com/inference-gateway/schemas/{{.SCHEMAS_REF | default "refs/heads/main"}}/openapi.yaml"
 
   generate-types:
     desc: Generate src/generated/schemas.rs from openapi.yaml
@@ -12,7 +12,7 @@ tasks:
       - cargo run -p gen-types --release
 
   oas-sync:
-    desc: Refresh openapi.yaml from upstream and regenerate Rust types
+    desc: Fetch the OpenAPI spec (pin with SCHEMAS_REF) and regenerate Rust types
     cmds:
       - task: oas-download
       - task: generate-types


### PR DESCRIPTION
## Summary

Part of the org-wide deterministic schemas→types sync (replaces the manual per-repo regeneration chore):

- Standardizes the Taskfile sync contract: `oas-download` now accepts `SCHEMAS_REF` (`refs/tags/vX.Y.Z`, a branch ref, or a SHA; default `refs/heads/main`), and `oas-sync` chains download + codegen as the single entry point.
- `oas-sync` already existed; `oas-download` gains the `SCHEMAS_REF` pin (codegen already pinned via Cargo.lock).
- Adds `.github/workflows/schemas-sync.yml`, a thin caller of the org reusable workflow `inference-gateway/.github/.github/workflows/schemas-sync.yml@main`. It regenerates types against a pinned schemas ref and opens/updates an idempotent PR on the fixed `schemas-sync` branch. Dispatch it from this repo's Actions tab, or fan out to all consumers via `sync-downstream.yml` in `inference-gateway/schemas`.

Verified locally: `task oas-sync SCHEMAS_REF=refs/tags/v0.10.0` downloads the pinned spec and regenerates deterministically.

## Impacted repos

Same rollout lands in: `inference-gateway/.github` (reusable workflow; SDK LLM drift audit retired, docs audit kept), `sdk`, `python-sdk`, `rust-sdk`, `typescript-sdk`, `inference-gateway`, and `schemas` (fan-out dispatcher).
